### PR TITLE
GH-783 release v2.0.0

### DIFF
--- a/.github/config/linter/.markdown-lint.yml
+++ b/.github/config/linter/.markdown-lint.yml
@@ -8,6 +8,10 @@ MD013:
   line_length: 100
   tables: false # Disable line length for tables
 
+# Allow repeated section names under different version headings (e.g. Changed)
+MD024:
+  siblings_only: true
+
 # Ordered list item prefix
 MD029:
   style: one_or_ordered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.0.0](https://github.com/akefirad/manual-approval-action/compare/v1.1.0...v2.0.0) - 2026-08-17
+
+### Breaking
+
+- **Node 24 runtime**: The action now runs on Node 24 (`runs.using: node24`). GitHub-hosted
+  runners that support Node 24 are required.
+
+### Changed
+
+- **Effect v4**: Internal implementation upgraded to Effect `4.0.0-rc.110` (from the v3-based
+  rewrite). Approval and cleanup behavior is unchanged.
+- **Issue size limits**: Titles longer than 256 characters and bodies longer than 65,536
+  characters are truncated to GitHub's API limits, with a warning in the job log.
+- **Tooling**: Oxlint/Oxfmt replace the previous linters/formatters. GitHub Actions in this
+  repository are pinned to release SHAs.
+
 ## [1.1.0](https://github.com/akefirad/manual-approval-action/compare/v1.0.0...v1.1.0) - 2025-08-15
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manual-approval-action",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manual-approval-action",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manual-approval-action",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "private": false,
   "description": "Manual Approval GitHub Action",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump the package version to 2.0.0
- Document the Node 24 runtime break, Effect v4 RC upgrade, and other changes since v1.1.0

Closes #783

## Test plan
- [ ] CI checks on this PR
- [ ] After merge: tag `v2.0.0`, point `v2` at the same commit, and publish GitHub Releases for both


Made with [Cursor](https://cursor.com)